### PR TITLE
version: automatically inherit version string from GOLANG

### DIFF
--- a/trace2receiver_version.go
+++ b/trace2receiver_version.go
@@ -1,4 +1,0 @@
-package trace2receiver
-
-// This value will be overwritten during release builds.
-var Trace2ReceiverVersion string = "v0.0.0"

--- a/version.go
+++ b/version.go
@@ -1,0 +1,39 @@
+package trace2receiver
+
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Automatically set our version string using the (usually canonical)
+// semantic version tag specified in a `require` in the `go.mod` of the
+// executable into which we are linked.  https://go.dev/ref/mod#vcs-find
+//
+// Note that modules are consumed in source form, rather than as binary
+// artifacts, so we cannot force the consumer to build with `-ldflags`
+// to set `-X '<var>=<ver>` in their build scripts.
+//
+// Also, we don't want to force a manual update of a hard-coded constant
+// when we create a tag; that is too easy to forget.
+//
+// Since GOLANG bakes this information into the binary, let's extract
+// it and use it.  See also: `git version -m <exe>`.
+//
+// We should always create a tag of the form `v<i>.<j>.<k>` when we
+// make a release.  And let the consumer ask for it by name.  We set
+// the default here in case we are not consumed as a module, such as
+// in our local unit tests.
+
+var Trace2ReceiverVersion string = "v0.0.0-unset"
+
+func init() {
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for k := range bi.Deps {
+			p := bi.Deps[k].Path
+			if strings.Contains(p, "trace2receiver") {
+				Trace2ReceiverVersion = bi.Deps[k].Version
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
Use the GOLANG module version string referenced by the containing executable for our component version string.

Custom collectors will consume our trace2receiver component using a `require` statement in their `go.mod`.  When building the collector, `go get` will fetch the corresponding commit or tag for each referenced component and store that in the resulting executable.

Use that so that we don't have to manually insert a version number into the source code or require that build automation do it.

Normally, collectors will reference us by a tag of the form `v<i>.<j>.<k>` in their `go.mod` and GO will checkout and use the associated commit in the build.  Inside our component, we can lookup that number/string value from the build meta data.  We will use that value to build the `InstrumentationScope` and pass to OTLP.

Note that developers can request a non-tagged commit using `go get github.com/github/trace2receiver@<sha>` (note that we don't need "https://" prefix) (and assuming that that string appears in `GOPRIVATE`).  This will cause GO to fetch the commit and update `go.mod` to refer to a pseudo version (of the form `v<i>.<j>.<k+1>-<timestamp>-<sha_prefix>`)