### PR TITLE
rcvr_namedpipe: set explicit ACL on named pipe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.12.0 // indirect
-	golang.org/x/sys v0.10.0
+	golang.org/x/sys v0.13.0
 	golang.org/x/text v0.11.0 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
 	google.golang.org/grpc v1.56.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/internal/go-winio/pipe_test.go
+++ b/internal/go-winio/pipe_test.go
@@ -81,7 +81,7 @@ func TestDialListenerGetsCancelled(t *testing.T) {
 
 func TestDialAccessDeniedWithRestrictedSD(t *testing.T) {
 	c := PipeConfig{
-		SecurityDescriptor: "D:P(A;;0x1200FF;;;WD)",
+		SDDL: "D:P(A;;0x1200FF;;;WD)",
 	}
 	l, err := ListenPipe(testPipeName, &c)
 	if err != nil {


### PR DESCRIPTION
If the call to create the server side of the named pipe does not specify an ACL the pipe code uses `RtlDefaultNpAcl()` to create a default ACL for the pipe:

    RW NT AUTHORITY\SYSTEM
    RW BUILTIN\Administrators
    R  Everyone
    R  NT AUTHORITY\ANONYMOUS LOGON

If the current user is not a member of `Administrators` then they won't be able open a client side pipe for writing to send data to the service.  Also, we should open it up in case there are multiple user accounts on the system.

Add an ACL to the pipe to allow that.

    RW NT AUTHORITY\SYSTEM
    RW BUILTIN\Administrators
    RW CREATOR OWNER
    RW Everyone

Also, make a slight change to the Microsoft/go-winio API to reduce confusion. Rename the PipeConfig.SecurityDescriptor field to better indicate that it is an SDDL rather than a binary structure.  Pass the SDDL to private routines rather than a `sd []byte` and avoid a lot of `unsafe.Pointer` casting.