### PR TITLE
rcvr_unixsocket: delete stray debug message

### DIFF
--- a/rcvr_unixsocket.go
+++ b/rcvr_unixsocket.go
@@ -282,7 +282,6 @@ func (rcvr *Rcvr_UnixSocket) listenLoop() {
 					break LOOP
 				}
 				rcvr.mutex.Unlock()
-				rcvr.Base.Logger.Info(fmt.Sprintf("socket still alive: %v", inode))
 			}
 		}
 	}()


### PR DESCRIPTION
I forgot to remove a debug message in my last round of changes prior to v0.5.0.