### PR TITLE
Initialize the tr2.exec map in NewTrace2Dataset

### DIFF
--- a/trace2dataset.go
+++ b/trace2dataset.go
@@ -258,6 +258,7 @@ func NewTrace2Dataset(rcvr_base *Rcvr_Base) *trace2Dataset {
 	tr2.process.paramSetPriorities = make(map[string]int)
 
 	tr2.pii = make(map[string]string)
+	tr2.exec = make(map[int64]*TrExec)
 
 	return tr2
 }


### PR DESCRIPTION
Currently, the `trace2Dataset` struct is not initialized with the `exec` map, so any exec event being parsed results in a panic in `evt_apply.go -> apply__exec -> l528`

```
{"kind": "receiver", "name": "trace2receiver", "data_type": "traces"}
2024-07-10T18:06:23.433Z debug com_github_git_ecosystem_trace2receiver/evt_parse.go:135 [dsid 000002] saw: {"event":"exec","sid":"20240710T180623.433066Z-Hb0b1f90b-P000222e8","thread":"main","time":"2024-07-10T18:06:23.433136Z","file":"external/com_git_scm_git/run-command.c","line":243,"exec_id":0,"exe":"git","argv":["git","upload-pack","/tmp/repo"]}
{"kind": "receiver", "name": "trace2receiver", "data_type": "traces"}
panic: assignment to entry in nil map

goroutine 60 [running]:
[github.com/git-ecosystem/trace2receiver.apply__exec(0xc000130b40](http://github.com/git-ecosystem/trace2receiver.apply__exec(0xc000130b40), 0xc00051f200)
external/com_github_git_ecosystem_trace2receiver/evt_apply.go:528 +0x1b6
[github.com/git-ecosystem/trace2receiver.evt_apply(0xc00070c300](http://github.com/git-ecosystem/trace2receiver.evt_apply(0xc00070c300)?, 0xc00051f200)
external/com_github_git_ecosystem_trace2receiver/evt_apply.go:28 +0x5b
[github.com/git-ecosystem/trace2receiver.processRawLine({0xc00070c300](http://github.com/git-ecosystem/trace2receiver.processRawLine(%7B0xc00070c300), 0xf6, 0xf6}, 0xc000130b40, 0x0?, 0x0?)
external/com_github_git_ecosystem_trace2receiver/evt_parse.go:146 +0x125
[github.com/git-ecosystem/trace2receiver.(*Rcvr_UnixSocket).worker(0xc00010f6e0](http://github.com/git-ecosystem/trace2receiver.(*Rcvr_UnixSocket).worker(0xc00010f6e0), 0xc0000f4090, 0x0?)
external/com_github_git_ecosystem_trace2receiver/rcvr_unixsocket.go:228 +0x315
created by [github.com/git-ecosystem/trace2receiver.(*Rcvr_UnixSocket).listenLoop](http://github.com/git-ecosystem/trace2receiver.(*Rcvr_UnixSocket).listenLoop) in goroutine 24
external/com_github_git_ecosystem_trace2receiver/rcvr_unixsocket.go:156 +0x1a5
```