### PR TITLE
CODEOWNERS: fix syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,2 @@
 # This repository is maintained by:
-* @dscho
-* @mjcheetham
-* @mpysson
+* @dscho @mjcheetham @mpysson


### PR DESCRIPTION
I mistakenly thought that this was a Markdown enumeration. But it is a file containing lines of the form `<file-pattern> <handle>...` instead. Which means that the `*` at the beginning of each line was interpreted as matching all files, and the last line overrode all previous ones.