### PR TITLE
Fix config parameter precedence for same-scope values

### DIFF
--- a/evt_apply.go
+++ b/evt_apply.go
@@ -582,9 +582,11 @@ func apply__def_param(tr2 *trace2Dataset, evt *TrEvent) (err error) {
 	_, havePrevVal := tr2.process.paramSetValues[key]
 	priCur, havePrevPri := tr2.process.paramSetPriorities[key]
 
-	if havePrevVal && havePrevPri && priNew <= priCur {
+	if havePrevVal && havePrevPri && priNew < priCur {
 		// We already have a value for this key with a higher
 		// priority, so ignore this value.
+		// Note: When priorities are equal, we accept the new value
+		// to match Git's "last one wins" behavior.
 		return nil
 	}
 


### PR DESCRIPTION
From `git config`'s documentation:

> The files are read in the order given above, with last value found taking precedence over values read earlier.

Currently, we discard values if we already have one with the same priority. However, this gives us "first one wins" semantics, which is incorrect.

By instead only discarding values if we already have one with a higher priority, we can achieve "last one wins" semantics, matching `git`.

---

This is of particular importance because we use config values to resolve the nickname and ruleset fields, so the value we resolve must match what a user would expect when writing their config. For example, consider the following git config:

    [otel.trace2]
      ruleset = dl:drop # Drop traces by default)

    [includeIf "hasconfig:remote.*.url:https://example.com/my-repo.git"]
      path = my-repo-tracing.gitconfig

and in my-repo-tracing.gitconfig

    [otel.trace2]
      ruleset = dl:verbose # Collect detailed traces for my-repo

Because we have "first one wins" semantics instead of git's "last one wins" semantics, the override doesn't do anything and traces are dropped unconditionally.