### PR TITLE
Emit repo nickname as process span attribute

### DIFF
--- a/trace2dataset.go
+++ b/trace2dataset.go
@@ -510,7 +510,7 @@ func (tr2 *trace2Dataset) exportTraces() {
 		return
 	}
 
-	traces := tr2.ToTraces(dl)
+	traces := tr2.ToTraces(dl, tr2.rcvr_base.RcvrConfig.filterSettings.Keynames)
 
 	err := tr2.rcvr_base.TracesConsumer.ConsumeTraces(tr2.rcvr_base.ctx, traces)
 	if err != nil {

--- a/trace2semconv.go
+++ b/trace2semconv.go
@@ -99,6 +99,8 @@ const (
 	Trace2RepoSet  = attribute.Key("trace2.repo.set")
 	Trace2ParamSet = attribute.Key("trace2.param.set")
 
+	Trace2RepoNickname = attribute.Key("trace2.repo.nickname")
+
 	Trace2ProcessData     = attribute.Key("trace2.process.data")
 	Trace2ProcessTimers   = attribute.Key("trace2.process.timers")
 	Trace2ProcessCounters = attribute.Key("trace2.process.counters")


### PR DESCRIPTION
If we have a repo nickname value present in the trace2.param.set, then emit this as a process span attribute directly "trace2.repo.nickname". This will make it easier to make decisions on routing of these traces in the collector, without having to resort to parsing the trace2.param.set JSON object.