### PR TITLE
Update Windows CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-2019 ]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The `windows-2019` agent image has been removed. We move to `windows-latest` to avoid this in the future. We should be testing on the latest Windows as we go forward since we want to make sure our forked copy of the Windows named pipe IO handling continues to work correctly with new Windows versions.