### PR TITLE
Allow `nil` filter settings

### DIFF
--- a/trace2dataset.go
+++ b/trace2dataset.go
@@ -522,7 +522,11 @@ func (tr2 *trace2Dataset) exportTraces() {
 		return
 	}
 
-	traces := tr2.ToTraces(dl, tr2.rcvr_base.RcvrConfig.filterSettings.Keynames)
+	var keynames FilterKeynames
+	if tr2.rcvr_base.RcvrConfig.filterSettings != nil {
+		keynames = tr2.rcvr_base.RcvrConfig.filterSettings.Keynames
+	}
+	traces := tr2.ToTraces(dl, keynames)
 
 	err := tr2.rcvr_base.TracesConsumer.ConsumeTraces(tr2.rcvr_base.ctx, traces)
 	if err != nil {


### PR DESCRIPTION
If you do no specify filter settings in the trace2receiver config then you hit a null pointer exception at runtime as we try to access the `Keynames` member of a `nil` `*FilterSettings`.

E.g.,

```yaml
receivers:
  trace2receiver:
    pipe: "//./pipe/pipe-name"
```